### PR TITLE
change in call of openslides, closes #1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
 FROM python:2
+ENV RESETADMIN "/data/resetadmin"
 RUN pip install openslides
 RUN mkdir /data
 RUN mkdir /data/config
@@ -7,6 +8,10 @@ RUN mkdir -p /root/.config
 RUN mkdir -p /root/.local/share
 RUN ln -s /data/config /root/.config/openslides
 RUN ln -s /data/share /root/.local/share/openslides
+RUN touch "$RESETADMIN"
 VOLUME /data
 EXPOSE 80
-CMD ["openslides"]
+CMD openslides syncdb; \
+    test -e "$RESETADMIN" && openslides createsuperuser && rm "$RESETADMIN"; \
+    openslides runserver
+


### PR DESCRIPTION
The server cannot be started with `openslidesstart`, but needs `openslides runserver`, but after database and admin is setup. Admin should be created only on first run.

Recreating the file /data/resetadmin in the volume allows to reset the admin account on next restart, should the user ever forget it. And if the "firstrun" file it is in the volume, it is backuped, therefore persistent when the process-container is recreated (i.e. updated).
